### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "polymer-ui-base-css": "Polymer/polymer-ui-base#~0.2.0",
     "polymer-ui-toolbar": "Polymer/polymer-ui-toolbar#~0.2.0",
     "platform": "Polymer/platform#~0.2.0",
-    "prismjs": "*"
+    "prism": "*"
   },
   "resolutions": {
     "polymer": "master",


### PR DESCRIPTION
Rename prismjs to prism to avoid error "ENOTFOUND Package prismjs not found" while installing polymer-ui-carousel
